### PR TITLE
Support kotlin.time.Instant (#501)

### DIFF
--- a/hoplite-core/src/main/resources/META-INF/services/com.sksamuel.hoplite.decoder.Decoder
+++ b/hoplite-core/src/main/resources/META-INF/services/com.sksamuel.hoplite.decoder.Decoder
@@ -3,6 +3,7 @@ com.sksamuel.hoplite.decoder.LocalDateDecoder
 com.sksamuel.hoplite.decoder.LocalDateTimeDecoder
 com.sksamuel.hoplite.decoder.LocalTimeDecoder
 com.sksamuel.hoplite.decoder.InstantDecoder
+com.sksamuel.hoplite.decoder.KotlinInstantDecoder
 com.sksamuel.hoplite.decoder.DurationDecoder
 com.sksamuel.hoplite.decoder.KotlinDurationDecoder
 com.sksamuel.hoplite.decoder.PeriodDecoder

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -50,7 +50,7 @@ enableFeaturePreview("TYPESAFE_PROJECT_ACCESSORS")
 dependencyResolutionManagement {
    versionCatalogs {
       create("libs") {
-         val kotlin = "2.1.0"
+         val kotlin = "2.2.0"
          plugin("kotlin-jvm", "org.jetbrains.kotlin.jvm").version(kotlin)
          plugin("kotlin-serialization","org.jetbrains.kotlin.plugin.serialization").version(kotlin)
          library("kotlin-reflect", "org.jetbrains.kotlin:kotlin-reflect:$kotlin")


### PR DESCRIPTION
The new Decoder is added to the SPI services by default. It correctly decodes kotlin.time.Instant fields when using Kotlin 2.2.0 whilst not breaking pre-2.1.20 applications.